### PR TITLE
Fix circular import error

### DIFF
--- a/gymnasium_robotics/__init__.py
+++ b/gymnasium_robotics/__init__.py
@@ -1,7 +1,8 @@
 # noqa: D104
 from gymnasium.envs.registration import register
-from gymnasium_robotics.envs.multiagent_mujoco import mamujoco_v0, MultiAgentMujocoEnv
+
 from gymnasium_robotics.core import GoalEnv
+from gymnasium_robotics.envs.multiagent_mujoco import MultiAgentMujocoEnv, mamujoco_v0
 
 
 def register_robotics_envs():

--- a/gymnasium_robotics/__init__.py
+++ b/gymnasium_robotics/__init__.py
@@ -1,6 +1,6 @@
 # noqa: D104
 from gymnasium.envs.registration import register
-
+from gymnasium_robotics.envs.multiagent_mujoco import mamujoco_v0, MultiAgentMujocoEnv
 from gymnasium_robotics.core import GoalEnv
 
 

--- a/gymnasium_robotics/envs/multiagent_mujoco/__init__.py
+++ b/gymnasium_robotics/envs/multiagent_mujoco/__init__.py
@@ -1,6 +1,14 @@
 """See the [Doc Page](https://robotics.farama.org/envs/fetch/MaMuJoCo)."""
 
-from gymnasium_robotics.envs.multiagent_mujoco.coupled_half_cheetah import CoupledHalfCheetah  # noqa: F401
-from gymnasium_robotics.envs.multiagent_mujoco.many_segment_ant import ManySegmentAntEnv  # noqa: F401
-from gymnasium_robotics.envs.multiagent_mujoco.many_segment_swimmer import ManySegmentSwimmerEnv  # noqa: F401
-from gymnasium_robotics.envs.multiagent_mujoco.mujoco_multi import MultiAgentMujocoEnv  # noqa: F401
+from gymnasium_robotics.envs.multiagent_mujoco.coupled_half_cheetah import (  # noqa: F401
+    CoupledHalfCheetah,
+)
+from gymnasium_robotics.envs.multiagent_mujoco.many_segment_ant import (  # noqa: F401
+    ManySegmentAntEnv,
+)
+from gymnasium_robotics.envs.multiagent_mujoco.many_segment_swimmer import (  # noqa: F401
+    ManySegmentSwimmerEnv,
+)
+from gymnasium_robotics.envs.multiagent_mujoco.mujoco_multi import (  # noqa: F401
+    MultiAgentMujocoEnv,
+)

--- a/gymnasium_robotics/envs/multiagent_mujoco/__init__.py
+++ b/gymnasium_robotics/envs/multiagent_mujoco/__init__.py
@@ -1,7 +1,6 @@
 """See the [Doc Page](https://robotics.farama.org/envs/fetch/MaMuJoCo)."""
 
-import multiagent_mujoco.mamujoco_v0  # noqa: F401
-from multiagent_mujoco.coupled_half_cheetah import CoupledHalfCheetah  # noqa: F401
-from multiagent_mujoco.many_segment_ant import ManySegmentAntEnv  # noqa: F401
-from multiagent_mujoco.many_segment_swimmer import ManySegmentSwimmerEnv  # noqa: F401
-from multiagent_mujoco.mujoco_multi import MultiAgentMujocoEnv  # noqa: F401
+from gymnasium_robotics.envs.multiagent_mujoco.coupled_half_cheetah import CoupledHalfCheetah  # noqa: F401
+from gymnasium_robotics.envs.multiagent_mujoco.many_segment_ant import ManySegmentAntEnv  # noqa: F401
+from gymnasium_robotics.envs.multiagent_mujoco.many_segment_swimmer import ManySegmentSwimmerEnv  # noqa: F401
+from gymnasium_robotics.envs.multiagent_mujoco.mujoco_multi import MultiAgentMujocoEnv  # noqa: F401

--- a/gymnasium_robotics/envs/multiagent_mujoco/mamujoco_v0.py
+++ b/gymnasium_robotics/envs/multiagent_mujoco/mamujoco_v0.py
@@ -1,4 +1,8 @@
-from gymnasium_robotics.envs.multiagent_mujoco.mujoco_multi import env, parallel_env, raw_env  # noqa : F401
+from gymnasium_robotics.envs.multiagent_mujoco.mujoco_multi import (  # noqa : F401
+    env,
+    parallel_env,
+    raw_env,
+)
 
 # TODO export get_parts_and_edges
 # from multiagent_mojoco.obsk import get_parts_and_edges  # noqa : F401

--- a/gymnasium_robotics/envs/multiagent_mujoco/mamujoco_v0.py
+++ b/gymnasium_robotics/envs/multiagent_mujoco/mamujoco_v0.py
@@ -1,4 +1,4 @@
-from multiagent_mujoco.mujoco_multi import env, parallel_env, raw_env  # noqa : F401
+from gymnasium_robotics.envs.multiagent_mujoco.mujoco_multi import env, parallel_env, raw_env  # noqa : F401
 
 # TODO export get_parts_and_edges
 # from multiagent_mojoco.obsk import get_parts_and_edges  # noqa : F401

--- a/gymnasium_robotics/envs/multiagent_mujoco/mujoco_multi.py
+++ b/gymnasium_robotics/envs/multiagent_mujoco/mujoco_multi.py
@@ -4,9 +4,14 @@ import gymnasium
 import numpy as np
 import pettingzoo
 from gymnasium.wrappers.time_limit import TimeLimit
-from gymnasium_robotics.envs.multiagent_mujoco.coupled_half_cheetah import CoupledHalfCheetah
+
+from gymnasium_robotics.envs.multiagent_mujoco.coupled_half_cheetah import (
+    CoupledHalfCheetah,
+)
 from gymnasium_robotics.envs.multiagent_mujoco.many_segment_ant import ManySegmentAntEnv
-from gymnasium_robotics.envs.multiagent_mujoco.many_segment_swimmer import ManySegmentSwimmerEnv
+from gymnasium_robotics.envs.multiagent_mujoco.many_segment_swimmer import (
+    ManySegmentSwimmerEnv,
+)
 from gymnasium_robotics.envs.multiagent_mujoco.obsk import (
     _observation_structure,
     build_obs,

--- a/gymnasium_robotics/envs/multiagent_mujoco/mujoco_multi.py
+++ b/gymnasium_robotics/envs/multiagent_mujoco/mujoco_multi.py
@@ -4,10 +4,10 @@ import gymnasium
 import numpy as np
 import pettingzoo
 from gymnasium.wrappers.time_limit import TimeLimit
-from multiagent_mujoco.coupled_half_cheetah import CoupledHalfCheetah
-from multiagent_mujoco.many_segment_ant import ManySegmentAntEnv
-from multiagent_mujoco.many_segment_swimmer import ManySegmentSwimmerEnv
-from multiagent_mujoco.obsk import (
+from gymnasium_robotics.envs.multiagent_mujoco.coupled_half_cheetah import CoupledHalfCheetah
+from gymnasium_robotics.envs.multiagent_mujoco.many_segment_ant import ManySegmentAntEnv
+from gymnasium_robotics.envs.multiagent_mujoco.many_segment_swimmer import ManySegmentSwimmerEnv
+from gymnasium_robotics.envs.multiagent_mujoco.obsk import (
     _observation_structure,
     build_obs,
     get_joints_at_kdist,

--- a/gymnasium_robotics/envs/multiagent_mujoco/obsk.py
+++ b/gymnasium_robotics/envs/multiagent_mujoco/obsk.py
@@ -208,7 +208,7 @@ def build_obs(
     return np.array(obs_lst)
 
 
-def get_parts_and_edges(
+def get_parts_and_edges(  # noqa: C901
     label: str, partitioning: str | None
 ) -> list[tuple[Node, ...], list[HyperEdge], dict[str, list[Node]]]:
     """Gets the mujoco Graph (nodes & edges) given an optional partitioning,.

--- a/gymnasium_robotics/envs/robot_env.py
+++ b/gymnasium_robotics/envs/robot_env.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 import numpy as np
 from gymnasium import error, logger, spaces
 
-from gymnasium_robotics import GoalEnv
+from gymnasium_robotics.core import GoalEnv
 
 try:
     import mujoco_py


### PR DESCRIPTION
# Description
- Remove importing `GoalEnv` as a public attribute from `gymnasium_robotics` in the `robot_env.py` file. This avoids the circular import error.
- Add `mamujoco_v0` and `MultiAgentMujocoEnv` as public attributes.
- Skip flake8 C901 in `get_parts_and_edges()`. 
 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
