### PR TITLE
 `gymnasium==1.0` support (#211)

### DIFF
--- a/docs/content/multi-goal_api.md
+++ b/docs/content/multi-goal_api.md
@@ -21,6 +21,9 @@ goal, e.g. state derived from the simulation.
 
 ```python
 import gymnasium as gym
+import gymnasium_robotics
+
+gym.register_envs(gymnasium_robotics)
 
 env = gym.make("FetchReach-v2")
 env.reset()

--- a/docs/envs/franka_kitchen/index.md
+++ b/docs/envs/franka_kitchen/index.md
@@ -16,6 +16,9 @@ The tasks can be selected when the environment is initialized passing a list of 
 ```python
 
 import gymnasium as gym
+import gymnasium_robotics
+
+gym.register_envs(gymnasium_robotics)
 
 env = gym.make('FrankaKitchen-v1', tasks_to_complete=['microwave', 'kettle'])
 ```

--- a/docs/envs/shadow_dexterous_hand/index.md
+++ b/docs/envs/shadow_dexterous_hand/index.md
@@ -22,6 +22,9 @@ These environments are instanceated by adding the following strings to the Hand 
 
 ```python
 import gymnasium as gym
+import gymnasium_robotics
+
+gym.register_envs(gymnasium_robotics)
 
 env = gym.make('HandManipulateEgg_BooleanTouchSensors-v1')
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,10 @@ The creation and interaction with the robotic environments follow the Gymnasium 
 ```{code-block} python
 
 import gymnasium as gym
+import gymnasium_robotics
+
+gym.register_envs(gymnasium_robotics)
+
 env = gym.make("FetchPickAndPlace-v2", render_mode="human")
 observation, info = env.reset(seed=42)
 for _ in range(1000):

--- a/gymnasium_robotics/__init__.py
+++ b/gymnasium_robotics/__init__.py
@@ -5,6 +5,8 @@ from gymnasium_robotics.core import GoalEnv
 from gymnasium_robotics.envs.maze import maps
 from gymnasium_robotics.envs.multiagent_mujoco import mamujoco_v0
 
+__version__ = "1.2.4"
+
 
 def register_robotics_envs():
     """Register all environment ID's to Gymnasium."""
@@ -1237,7 +1239,7 @@ def register_robotics_envs():
     )
 
 
-__version__ = "1.2.4"
+register_robotics_envs()
 
 
 try:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -163,6 +163,9 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('AdroitHandDoor-v1', max_episode_steps=400)
     ```

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -172,6 +172,9 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('AdroitHandHammer-v1', max_episode_steps=400)
     ```

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -165,6 +165,9 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('AdroitHandPen-v1', max_episode_steps=400)
     ```

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -165,6 +165,9 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('AdroitHandRelocate-v1', max_episode_steps=400)
     ```

--- a/gymnasium_robotics/envs/fetch/pick_and_place.py
+++ b/gymnasium_robotics/envs/fetch/pick_and_place.py
@@ -92,6 +92,9 @@ class MujocoFetchPickAndPlaceEnv(MujocoFetchEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('FetchPickAndPlaceDense-v2')
     ```
@@ -118,6 +121,9 @@ class MujocoFetchPickAndPlaceEnv(MujocoFetchEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('FetchPickAndPlace-v2', max_episode_steps=100)
     ```

--- a/gymnasium_robotics/envs/fetch/push.py
+++ b/gymnasium_robotics/envs/fetch/push.py
@@ -120,6 +120,9 @@ class MujocoFetchPushEnv(MujocoFetchEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('FetchPushDense-v2')
     ```
@@ -146,6 +149,9 @@ class MujocoFetchPushEnv(MujocoFetchEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('FetchPush-v2', max_episode_steps=100)
     ```

--- a/gymnasium_robotics/envs/fetch/reach.py
+++ b/gymnasium_robotics/envs/fetch/reach.py
@@ -82,6 +82,9 @@ class MujocoFetchReachEnv(MujocoFetchEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('FetchReachDense-v2')
     ```
@@ -104,6 +107,9 @@ class MujocoFetchReachEnv(MujocoFetchEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('FetchReach-v2', max_episode_steps=100)
     ```

--- a/gymnasium_robotics/envs/fetch/slide.py
+++ b/gymnasium_robotics/envs/fetch/slide.py
@@ -120,6 +120,9 @@ class MujocoFetchSlideEnv(MujocoFetchEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('FetchSlideDense-v2')
     ```
@@ -145,6 +148,9 @@ class MujocoFetchSlideEnv(MujocoFetchEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('FetchSlide-v2', max_episode_steps=100)
     ```

--- a/gymnasium_robotics/envs/franka_kitchen/kitchen_env.py
+++ b/gymnasium_robotics/envs/franka_kitchen/kitchen_env.py
@@ -64,6 +64,10 @@ class KitchenEnv(GoalEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
+
     env = gym.make('FrankaKitchen-v1', tasks_to_complete=['microwave', 'kettle'])
     ```
 

--- a/gymnasium_robotics/envs/maze/ant_maze.py
+++ b/gymnasium_robotics/envs/maze/ant_maze.py
@@ -122,3 +122,11 @@ class AntMazeEnv(MazeEnv, EzPickle):
     def close(self):
         super().close()
         self.ant_env.close()
+
+    @property
+    def model(self):
+        return self.ant_env.model
+
+    @property
+    def data(self):
+        return self.ant_env.data

--- a/gymnasium_robotics/envs/maze/ant_maze_v4.py
+++ b/gymnasium_robotics/envs/maze/ant_maze_v4.py
@@ -65,6 +65,9 @@ class AntMazeEnv(MazeEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     example_map = [[1, 1, 1, 1, 1],
            [1, C, 0, C, 1],
@@ -158,6 +161,9 @@ class AntMazeEnv(MazeEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('AntMaze_UMaze-v4')
     ```
@@ -192,6 +198,9 @@ class AntMazeEnv(MazeEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('AntMaze_UMaze-v4', max_episode_steps=100)
     ```
@@ -319,3 +328,11 @@ class AntMazeEnv(MazeEnv, EzPickle):
     def close(self):
         super().close()
         self.ant_env.close()
+
+    @property
+    def model(self):
+        return self.ant_env.model
+
+    @property
+    def data(self):
+        return self.ant_env.data

--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -196,6 +196,9 @@ class PointMazeEnv(MazeEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     example_map = [[1, 1, 1, 1, 1],
            [1, C, 0, C, 1],
@@ -253,6 +256,9 @@ class PointMazeEnv(MazeEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('PointMaze_UMazeDense-v3')
     ```
@@ -286,6 +292,9 @@ class PointMazeEnv(MazeEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('PointMaze_UMaze-v3', max_episode_steps=100)
     ```
@@ -415,3 +424,11 @@ class PointMazeEnv(MazeEnv, EzPickle):
     def close(self):
         super().close()
         self.point_env.close()
+
+    @property
+    def model(self):
+        return self.point_env.model
+
+    @property
+    def data(self):
+        return self.point_env.data

--- a/gymnasium_robotics/envs/multiagent_mujoco/mujoco_multi.py
+++ b/gymnasium_robotics/envs/multiagent_mujoco/mujoco_multi.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import gymnasium
 import numpy as np
 import pettingzoo
-from gymnasium.wrappers.time_limit import TimeLimit
+from gymnasium.wrappers import TimeLimit
 
 from gymnasium_robotics.envs.multiagent_mujoco.coupled_half_cheetah import (
     CoupledHalfCheetahEnv,

--- a/gymnasium_robotics/envs/shadow_dexterous_hand/manipulate_block.py
+++ b/gymnasium_robotics/envs/shadow_dexterous_hand/manipulate_block.py
@@ -166,6 +166,9 @@ class MujocoHandBlockEnv(MujocoManipulateEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('HandManipulateBlock-v1')
     ```
@@ -193,6 +196,9 @@ class MujocoHandBlockEnv(MujocoManipulateEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('HandManipulateBlock-v1', max_episode_steps=100)
     ```
@@ -203,7 +209,6 @@ class MujocoHandBlockEnv(MujocoManipulateEnv, EzPickle):
 
     * v1: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v0: the environment depends on `mujoco_py` which is no longer maintained.
-
     """
 
     def __init__(

--- a/gymnasium_robotics/envs/shadow_dexterous_hand/manipulate_egg.py
+++ b/gymnasium_robotics/envs/shadow_dexterous_hand/manipulate_egg.py
@@ -169,6 +169,9 @@ class MujocoHandEggEnv(MujocoManipulateEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('HandManipulateEgg-v1')
     ```
@@ -196,6 +199,9 @@ class MujocoHandEggEnv(MujocoManipulateEnv, EzPickle):
 
     ```
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('HandManipulateEgg-v1', max_episode_steps=100)
     ```

--- a/gymnasium_robotics/envs/shadow_dexterous_hand/manipulate_pen.py
+++ b/gymnasium_robotics/envs/shadow_dexterous_hand/manipulate_pen.py
@@ -168,6 +168,9 @@ class MujocoHandPenEnv(MujocoManipulateEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('HandManipulatePen-v1')
     ```
@@ -195,6 +198,9 @@ class MujocoHandPenEnv(MujocoManipulateEnv, EzPickle):
 
     ```python
     import gymnasium as gym
+    import gymnasium_robotics
+
+    gym.register_envs(gymnasium_robotics)
 
     env = gym.make('HandManipulatePen-v1', max_episode_steps=100)
     ```
@@ -205,7 +211,6 @@ class MujocoHandPenEnv(MujocoManipulateEnv, EzPickle):
 
     * v1: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v0: the environment depends on `mujoco_py` which is no longer maintained.
-
     """
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ]
 dependencies = [
-    "mujoco>=2.3.3, <3.0",
+    "mujoco>=2.2.0",
     "numpy>=1.21.0",
-    "gymnasium>=0.26",
+    "gymnasium>=1.0.0a1",
     "PettingZoo>=1.23.0",
     "Jinja2>=3.0.3",
     "imageio"

--- a/tests/envs/franka_kitchen/test_kitchen_env.py
+++ b/tests/envs/franka_kitchen/test_kitchen_env.py
@@ -47,7 +47,7 @@ def test_task_completion(remove_task_when_completed, terminate_on_tasks_complete
         # Complete a task sequentially for each environment step
         for task in TASKS:
             # Force task to be achieved
-            env.data.qpos[OBS_ELEMENT_INDICES[task]] = OBS_ELEMENT_GOALS[task]
+            env.unwrapped.data.qpos[OBS_ELEMENT_INDICES[task]] = OBS_ELEMENT_GOALS[task]
             _, _, terminated, _, info = env.step(env.action_space.sample())
             completed_tasks.add(task)
 
@@ -91,7 +91,7 @@ def test_task_completion(remove_task_when_completed, terminate_on_tasks_complete
         # Complete a task sequentially for each environment step
         for task in TASKS:
             # Force task to be achieved
-            env.data.qpos[OBS_ELEMENT_INDICES[task]] = OBS_ELEMENT_GOALS[task]
+            env.unwrapped.data.qpos[OBS_ELEMENT_INDICES[task]] = OBS_ELEMENT_GOALS[task]
             completed_tasks.add(task)
 
         _, _, terminated, _, info = env.step(env.action_space.sample())

--- a/tests/envs/hand/test_manipulate.py
+++ b/tests/envs/hand/test_manipulate.py
@@ -16,7 +16,7 @@ def test_serialize_deserialize(environment_id):
     env1.reset()
     env2 = pickle.loads(pickle.dumps(env1))
 
-    assert env1.target_position == env2.target_position, (
+    assert env1.unwrapped.target_position == env2.unwrapped.target_position, (
         env1.target_position,
         env2.target_position,
     )

--- a/tests/envs/hand/test_manipulate_touch_sensors.py
+++ b/tests/envs/hand/test_manipulate_touch_sensors.py
@@ -16,7 +16,7 @@ def test_serialize_deserialize(environment_id):
     env1.reset()
     env2 = pickle.loads(pickle.dumps(env1))
 
-    assert env1.target_position == env2.target_position, (
+    assert env1.unwrapped.target_position == env2.unwrapped.target_position, (
         env1.target_position,
         env2.target_position,
     )

--- a/tests/envs/hand/test_reach.py
+++ b/tests/envs/hand/test_reach.py
@@ -8,7 +8,7 @@ def test_serialize_deserialize():
     env1.reset()
     env2 = pickle.loads(pickle.dumps(env1))
 
-    assert env1.distance_threshold == env2.distance_threshold, (
+    assert env1.unwrapped.distance_threshold == env2.unwrapped.distance_threshold, (
         env1.distance_threshold,
         env2.distance_threshold,
     )

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -14,7 +14,7 @@ CHECK_ENV_IGNORE_WARNINGS = [
     for message in [
         "This version of the mujoco environments depends on the mujoco-py bindings, which are no longer maintained and may stop working. Please upgrade to the v4 versions of the environments (which depend on the mujoco python bindings instead), unless you are trying to precisely replicate previous works).",
         "A Box observation space minimum value is -infinity. This is probably too low.",
-        "A Box observation space maximum value is -infinity. This is probably too high.",
+        "A Box observation space maximum value is infinity. This is probably too high.",
         "For Box action spaces, we recommend using a symmetric and normalized space (range=[-1, 1] or [0, 1]). See https://stable-baselines3.readthedocs.io/en/master/guide/rl_tips.html for more information.",
     ]
 ]


### PR DESCRIPTION
* WIP `gymnasium==1.0` support

* some fixes

* add `unwrapped` to `env` in `tests`

* `pre-commit`

* update DOCs `import` before `make`

* Update pyproject.toml

* Update pyproject.toml

* added `MazeEnv.model` and `MazeEnv.data`

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
